### PR TITLE
Update dependency ts-loader to v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
         "pretty-quick": "^1.6.0",
         "source-map-loader": "^0.2.0",
         "ts-jest": "^23.0.0",
-        "ts-loader": "^4.0.0",
+        "ts-loader": "^5.0.0",
         "ts-mockito": "^2.3.0",
         "tslint": "^5.0.0",
         "tslint-config-prettier": "^1.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3525,9 +3525,9 @@ ts-jest@^23.0.0:
     pkg-dir "^3.0.0"
     yargs "^12.0.1"
 
-ts-loader@^4.0.0:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-4.4.2.tgz#778d4464b24436873c78f7f9e914d88194c2a248"
+ts-loader@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-5.0.0.tgz#0715ee31ed229fcdc8df73e87ccd80e6a46cae04"
   dependencies:
     chalk "^2.3.0"
     enhanced-resolve "^4.0.0"


### PR DESCRIPTION
<p>This Pull Request updates dependency <a href="https://renovatebot.com/gh/TypeStrong/ts-loader">ts-loader</a> from <code>^4.0.0</code> to <code>^5.0.0</code></p>
<p><details><br />
<summary>Release Notes</summary></p>
<h3 id="v500httpsgithubcomtypestrongts-loaderblobmasterchangelogmd8203500"><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/blob/master/CHANGELOG.md#&#8203;500"><code>v5.0.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/compare/v4.5.0…v5.0.0">Compare Source</a></p>
<ul>
<li><a href="https://renovatebot.com/gh/TypeStrong/ts-loader/pull/822">feat: Fixed issue with incorrect output path for declaration files</a> - thanks <a href="https://renovatebot.com/gh/JonWallsten">@&#8203;JonWallsten</a>! <strong>BREAKING CHANGE</strong></li>
</ul>
<hr />
<p></details></p>
<hr />
<p>This PR has been generated by <a href="https://renovatebot.com">Renovate Bot</a>.</p>