### PR TITLE
Update dependency tslint-plugin-prettier to v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
         "tslint": "^5.0.0",
         "tslint-config-prettier": "^1.14.0",
         "tslint-loader": "^3.6.0",
-        "tslint-plugin-prettier": "^1.3.0",
+        "tslint-plugin-prettier": "^2.0.0",
         "tslint-react": "^3.6.0",
         "typescript": "^3.0.1"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3559,9 +3559,9 @@ tslint-loader@^3.6.0:
     rimraf "^2.4.4"
     semver "^5.3.0"
 
-tslint-plugin-prettier@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/tslint-plugin-prettier/-/tslint-plugin-prettier-1.3.0.tgz#7eb65d19ea786a859501a42491b78c5de2031a3f"
+tslint-plugin-prettier@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/tslint-plugin-prettier/-/tslint-plugin-prettier-2.0.0.tgz#ade328b26c71f37418d4d01187dca232a7447b49"
   dependencies:
     eslint-plugin-prettier "^2.2.0"
     tslib "^1.7.1"


### PR DESCRIPTION
<p>This Pull Request updates dependency <a href="https://renovatebot.com/gh/ikatyang/tslint-plugin-prettier">tslint-plugin-prettier</a> from <code>^1.3.0</code> to <code>^2.0.0</code></p>
<p><details><br />
<summary>Release Notes</summary></p>
<h3 id="v200httpsgithubcomikatyangtslint-plugin-prettierblobmasterchangelogmd8203200httpsgithubcomikatyangtslint-plugin-prettiercomparev130v200-2018-09-16"><a href="https://renovatebot.com/gh/ikatyang/tslint-plugin-prettier/blob/master/CHANGELOG.md#&#8203;200httpsgithubcomikatyangtslint-plugin-prettiercomparev130v200-2018-09-16"><code>v2.0.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/ikatyang/tslint-plugin-prettier/compare/v1.3.0…v2.0.0">Compare Source</a></p>
<h5 id="bug-fixes">Bug Fixes</h5>
<ul>
<li>specify config file correctly (<a href="https://renovatebot.com/gh/ikatyang/tslint-plugin-prettier/commit/a46bb9f">a46bb9f</a>)</li>
</ul>
<h5 id="features">Features</h5>
<ul>
<li>support .editorconfig (<a href="https://renovatebot.com/gh/ikatyang/tslint-plugin-prettier/commit/5afdfbc">5afdfbc</a>)</li>
</ul>
<h5 id="breaking-changes">BREAKING CHANGES</h5>
<ul>
<li>require <code>prettier@&amp;#8203;^1.9.0</code></li>
<li>load <code>.editorconfig</code> by default</li>
<li>specify config file via filepath instead of directory</li>
</ul>
<hr />
<p></details></p>
<hr />
<p>This PR has been generated by <a href="https://renovatebot.com">Renovate Bot</a>.</p>